### PR TITLE
Get LitElement from an existing component

### DIFF
--- a/card-tools.js
+++ b/card-tools.js
@@ -12,7 +12,7 @@ class {
   }
 
   static litElement() {
-    return Object.getPrototypeOf(customElements.get('hui-error-entity-row'));
+    return Object.getPrototypeOf(customElements.get('home-assistant-main'));
   }
 
   static litHtml() {


### PR DESCRIPTION
We removed entity-error-row, I doubt `<home-assistant-main>` will go away anytime soon 😉 