### PR TITLE
Make card-tools.js compatible with type: module

### DIFF
--- a/card-tools.js
+++ b/card-tools.js
@@ -420,7 +420,7 @@ class {
 });
 
 // Global definition of cardTools
-var cardTools = customElements.get('card-tools');
+window.cardTools = customElements.get('card-tools');
 
 console.info(`%cCARD-TOOLS IS INSTALLED
 %cDeviceID: ${customElements.get('card-tools').deviceID}`,


### PR DESCRIPTION
When a JavaScript file is loaded with type=module, variables don't leak into the main window object. So to make sure we write it to the window, we need to do that explicitly.

This will continue to work with `type: js` too.