### PR TITLE
Vertical align x in close button

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -96,7 +96,7 @@ export async function popUp(title, card, large=false, style={}, fullscreen=false
                     .label=${"dismiss"}
                     dialogAction="cancel"
                   >
-                    <ha-icon
+                    <ha-icon style="font-size: initial;"
                       .icon=${"mdi:close"}
                     ></ha-icon>
                   </mwc-icon-button>


### PR DESCRIPTION
Wonder if I'm the only one who wants to have the close X aligned correctly. Had this [PR](https://github.com/thomasloven/hass-browser_mod/pull/225 and https://github.com/thomasloven/hass-browser_mod/pull/261) already in the past, but I was linked to here, so next try, to have this centered on day. 😀

Unset font-size in ha-icon to have it not inherited from .mdc-icon-button and then as wanted vertical aligned in the mwc-icon-button.

old: 
![image](https://user-images.githubusercontent.com/22775515/118685544-7c9cde00-b803-11eb-9861-9f3d1da9dcc7.png)

new:
![image](https://user-images.githubusercontent.com/22775515/118685462-655df080-b803-11eb-946b-3867366be858.png)
